### PR TITLE
The "right" way of structuring action, reducer (and action types)

### DIFF
--- a/lib/create-action.js
+++ b/lib/create-action.js
@@ -8,7 +8,7 @@ function noop(payload = {}) {
 export default function createAction(type, payloadCreator, metaCreator) {
   payloadCreator = isFunc(payloadCreator) ? payloadCreator : noop
 
-  return (...args) => {
+  const fn = (...args) => {
     return (dispatch, getState) => {
       return Promise
         .resolve(payloadCreator.apply({getState}, args))
@@ -32,5 +32,7 @@ export default function createAction(type, payloadCreator, metaCreator) {
           return result
         })
     }
-  }
+  };
+  fn.type = type;
+  return fn;
 }

--- a/test/create-action.js
+++ b/test/create-action.js
@@ -4,6 +4,10 @@ import { equal, deepEqual } from 'assert'
 
 describe('## create-action', () => {
   describe('# basic', () => {
+    it('createAction(type)', () => {
+      const action = createAction('get items');
+      equal(action.type, 'get items')
+    });
     it('createAction(type, payload)', () => {
       const action = createAction('get items')
 


### PR DESCRIPTION
I'm curious what's your opinion on how we should structure actions, action types and reducers.

Scenario 1: Having separated `action-types.js`, `actions.js`, `reducer.js`

```
//action-types.js
const GET_ITEMS = 'get items';
```

```
//actions.js
import {
  GET_ITEMS
} from './action-types';
import { createAction } from 'redux-action';

export const getItems = createAction(GET_ITEMS);
```

```
//reducer.js
import {
  GET_ITEMS
} from './action-types';
import { createReducer } from 'redux-action';
export default createReducer({}, {
  [GET_ITEMS]: (payload, state) => ({...state, ...payload})
});
```

Scenario 2: Changing `createAction` by exporting the `type` of action, so we dont need `action-types.js`, just `actions.js` and `reducer.js`

```
//actions.js
import { createAction } from 'redux-action';
export const getItems = createAction('get items');
```

```
//reducer.js
import { createReducer } from 'redux-action';
import {
  getItems
} from './actions';
export default createReducer({}, {
  [getItems.type]: (payload, state) => ({...state, ...payload})
});
```

I added changes for Scenario 2 (since `redux-action` already supports the first one), but I'm just looking for your opinions on this very topic. We've been using the first option for quite a long time (a year or so), but that requires us to keep both three files up-to-date (and the tests as well), which is - to be honest - a real pain.
You can even mix the two options, by creating an `action-types.js` which is used by the `actions.js`, but the reducer uses the `actions.js` instead of the `action-types.js`, this can be handy if you want to use your constants in middlewares without requiring `actions.js`.

What's your take on this?